### PR TITLE
Do not run Homebrew's brew under sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ sudo apt-get install curl libsnappy-dev autoconf automake libtool pkg-config
 
 **On Mac OSX**
 ```
-sudo brew install snappy autoconf automake libtool pkg-config
+brew install snappy autoconf automake libtool pkg-config
 ```
 
 Then to install the C library:


### PR DESCRIPTION
This can cause permission problems otherwise.

The privilege elevation is not required for ~99% of users, as Homebrew's own advice is to install Formulas without `sudo` and therefore most people follow it: https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/FAQ.md#why-does-homebrew-say-sudo-is-bad-