### PR TITLE
don't error on multiple setup_parser()

### DIFF
--- a/src/geodb.c
+++ b/src/geodb.c
@@ -233,7 +233,7 @@ bool geodb_module_setup(char *dir) {
         return geodb_load(dir == NULL ? LIBPOSTAL_GEODB_DIR : dir);
     }
 
-    return false;
+    return true;
 }
 
 


### PR DESCRIPTION
I *think* this is harmless. `setup_parser()` is the only setup function to throw an error if it's called twice before its equivalent teardown function. This stops libpostal from throwing an error if `setup_parser()` has already been called.

```
#include <libpostal/libpostal.h>

int main(int argc, char **argv) {
  libpostal_setup();
  libpostal_setup_language_classifier();
  libpostal_setup_parser();
  libpostal_setup_parser();
  libpostal_teardown();
  libpostal_teardown_language_classifier();
  libpostal_teardown_parser();
}
```