### PR TITLE
Call libpostal_data in source path, not build path

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,7 +60,7 @@ language_classifier_test_CFLAGS = $(CFLAGS_O3)
 pkginclude_HEADERS = libpostal.h
 
 all-local:
-	./libpostal_data download all $(datadir)/libpostal
+	${srcdir}/libpostal_data download all $(datadir)/libpostal
 
 lexer: scanner.re
 	re2c -F -s -b -8 -o scanner.c scanner.re


### PR DESCRIPTION
A standard `configure` script allows you to use a separate path for the build simply by calling configure from the directory you want to use as the build directory.

This fix updates Makefile to find the actual libpostal_data file when
`configure` is called from another directory, which it uses as the build
directory.