### PR TITLE
Fix math so chunks never exceed `CHUNK_SIZE`

### DIFF
--- a/src/libpostal_data
+++ b/src/libpostal_data
@@ -67,6 +67,9 @@ function download_multipart() {
     num_workers=$4
 
     num_chunks=$((size/CHUNK_SIZE))
+    if [ $((num_chunks*CHUNK_SIZE)) -lt $size ]; then
+        num_chunks=$((num_chunks+1))
+    fi
     echo "Downloading multipart: $url, size=$size, num_chunks=$num_chunks"
     offset=0
     for i in $(seq 1 $((num_chunks))); do


### PR DESCRIPTION
When `size` is not *exactly* divisible by `CHUNK_SIZE`, `num_chunk` is
one (1) less than it should be and the last chunk is larger than
`CHUNK_SIZE` by the remainder (possibly as much as `CHUNK_SIZE-1`).

While working to fix my *posix_sh* pull request, I came across this and didn't know if it was something that should be fixed or if it already worked as intended.