### PR TITLE
Reduce connections for very large files

### DIFF
--- a/src/libpostal_data
+++ b/src/libpostal_data
@@ -67,6 +67,11 @@ function download_multipart() {
     num_workers=$4
 
     num_chunks=$((size/CHUNK_SIZE))
+    if [ $num_chunks -gt $num_workers ]; then
+        num_chunks=$num_workers
+    fi
+    chunk_size=$((size/num_chunks))
+
     echo "Downloading multipart: $url, size=$size, num_chunks=$num_chunks"
     offset=0
     i=0
@@ -74,13 +79,16 @@ function download_multipart() {
         i=$((i+1))
         part_filename="$filename.$i"
         if [ $i -lt $num_chunks ]; then
-            max=$((offset+CHUNK_SIZE-1));
+            max=$((offset+chunk_size-1));
         else
             max=$size;
         fi;
-        printf "%s\0%s\0%s\0%s\0%s\0" "$i" "$offset" "$max" "$url" "$part_filename"
-        offset=$((offset+CHUNK_SIZE))
-    done | xargs -0 -n 5 -P $NUM_WORKERS bash -c 'download_part "$@"' --
+        download_part "$i" "$offset" "$max" "$url" "$part_filename" &
+        offset=$((offset+chunk_size))
+    done
+
+    # wait for all download_part background jobs to complete
+    wait
 
     > $local_path
 


### PR DESCRIPTION
This is another question in the form of a pull request. Basically, is it okay to increase the size of all chunks to reduce the required number of connections while maintaining exactly the number of chunks for those large files smaller than `$NUM_WORKERS*$CHUNK_SIZE`?

This commit would have no effect on the number of chunks for downloads that would not need to delay any processes.

In cases where `$num_chunks` exceeds `$NUM_WORKERS` previously the
excessive downloads were put on hold until download processes fell below
`$NUM_WORKERS`.

In that case this commit reduces `$num_chunks` to be equal to
`$NUM_WORKERS` so that the total number of connections is reduced while
maintaining the desired parallelism.

This also balances the division remainder among all chunks so that the
last file is never more than `$num_workers` larger than the others,
which is a further optimization.