### PR TITLE
Unknown escape

### DIFF
--- a/src/address_expansion_data.c
+++ b/src/address_expansion_data.c
@@ -72586,7 +72586,7 @@ address_expansion_rule_t expansion_rules[] = {
     {"s statale", 1, {DICTIONARY_STREET_TYPE}, 2800},
     {"osta", 1, {DICTIONARY_PLACE_NAME}, 2673},
     {"giardini", 1, {DICTIONARY_SYNONYM}, -1},
-    {"c \ o", 1, {DICTIONARY_POST_OFFICE}, 2684},
+    {"c \\ o", 1, {DICTIONARY_POST_OFFICE}, 2684},
     {"sett", 1, {DICTIONARY_SYNONYM}, 2952},
     {"madonnella", 1, {DICTIONARY_PLACE_NAME}, -1},
     {"f.v.", 1, {DICTIONARY_PLACE_NAME}, 2644},

--- a/src/libpostal_data
+++ b/src/libpostal_data
@@ -67,6 +67,11 @@ function download_multipart() {
     num_workers=$4
 
     num_chunks=$((size/CHUNK_SIZE))
+    if [ $num_chunks -gt $num_workers ]; then
+        num_chunks=$num_workers
+    fi
+    chunk_size=$((size/num_chunks))
+
     echo "Downloading multipart: $url, size=$size, num_chunks=$num_chunks"
     offset=0
     i=0
@@ -74,13 +79,16 @@ function download_multipart() {
         i=$((i+1))
         part_filename="$filename.$i"
         if [ $i -lt $num_chunks ]; then
-            max=$((offset+CHUNK_SIZE-1));
+            max=$((offset+chunk_size-1));
         else
             max=$size;
         fi;
-        printf "%s\0%s\0%s\0%s\0%s\0" "$i" "$offset" "$max" "$url" "$part_filename"
-        offset=$((offset+CHUNK_SIZE))
-    done | xargs -0 -n 5 -P $NUM_WORKERS bash -c 'download_part "$@"' --
+        download_part "$i" "$offset" "$max" "$url" "$part_filename" &
+        offset=$((offset+chunk_size))
+    done
+
+    # wait for all download_part background jobs to complete
+    wait
 
     > $local_path
 


### PR DESCRIPTION
In file included from **…**/libpostal/src/address_dictionary_builder.c:6:
**…**/libpostal/src/address_expansion_data.c:72589:9: warning: 
      unknown escape sequence '\ '
    {"c \ o", 1, {DICTIONARY_POST_OFFICE}, 2684},
        ^~