### PR TITLE
changes required for cross-compilation of ARM target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,10 +45,8 @@ AC_TYPE_UINT8_T
 AC_CHECK_TYPES([ptrdiff_t])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
 AC_FUNC_MMAP
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([getcwd gettimeofday memmove memset munmap regcomp setlocale sqrt strdup strndup])
+AC_CHECK_FUNCS([malloc realloc getcwd gettimeofday memmove memset munmap regcomp setlocale sqrt strdup strndup])
 
 AC_CONFIG_FILES([Makefile
                  libpostal.pc
@@ -69,5 +67,19 @@ AC_ARG_ENABLE([data-download],
               esac], [DOWNLOAD_DATA=true])
 
 AM_CONDITIONAL([DOWNLOAD_DATA], [test "x$DOWNLOAD_DATA" = "xtrue"])
+
+AC_ARG_WITH(cflags-scanner-extra, [AS_HELP_STRING([--with-cflags-scanner-extra@<:@=VALUE@:>@], [Extra compilation options for scanner.c])],
+[
+ if test "x$withval" = "xno"; then
+    CFLAGS_SCANNER_EXTRA=""
+ else
+   CFLAGS_SCANNER_EXTRA="$withval"
+ fi
+],
+[ CFLAGS_SCANNER_EXTRA="" ]
+)
+
+AC_MSG_NOTICE([extra cflags for scanner.c: $CFLAGS_SCANNER_EXTRA])
+AC_SUBST(CFLAGS_SCANNER_EXTRA)
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,9 +22,11 @@ libpostal_la_CFLAGS = $(CFLAGS_O2)
 dist_bin_SCRIPTS = libpostal_data
 
 # Scanner can take a very long time to compile with higher optimization levels, so always use -O0, scanner is fast enough
+# On cross-compilation for ARM using gcc-4.7, there are "out of range" errors during compilation that can be fixed by adding
+# -marm option. For that, CFLAGS_SCANNER_EXTRA is provided that can be filled during configuration stage (see ./configure --help). 
 noinst_LTLIBRARIES = libscanner.la
 libscanner_la_SOURCES = scanner.c
-libscanner_la_CFLAGS = $(CFLAGS_O0)
+libscanner_la_CFLAGS = $(CFLAGS_O0) $(CFLAGS_SCANNER_EXTRA)
 
 noinst_PROGRAMS = libpostal bench build_address_dictionary build_geodb build_numex_table build_trans_table address_parser_train address_parser_test address_parser language_classifier_train language_classifier language_classifier_test
 libpostal_SOURCES = main.c json_encode.c


### PR DESCRIPTION
While compiling libpostal for ARM-powered Sailfish OS, I've got problems with AC_FUNC_MALLOC and _REALLOC leading to missing rpc_malloc during linking (https://github.com/openvenues/libpostal/issues/134). This seems to be a common problem for cross-compiling many projects and can be fixed by dropping AC_FUNC_MALLOC/REALLOC and checking for these functions in AC_CHECK_FUNCS.

In addition, probably due to gcc bug, gcc failed to compile scanner.c. To fix that, I needed to add -marm as an additional option. For that, I added a new flag for configuration stage that allows to do so:

--with-cflags-scanner-extra="-marm" 

would allow to compile the source. 

I hope that these changes are acceptable.