### PR TITLE
[fix] typo in compiler warning when no CBLAS found

### DIFF
--- a/src/matrix.h
+++ b/src/matrix.h
@@ -16,7 +16,7 @@
 #ifdef HAVE_CBLAS
 #include <cblas.h>
 #else
-#warning "No CLBAS"
+#warning "No CBLAS"
 #endif
 
 typedef enum {


### PR DESCRIPTION
Very minor cleanup. I saw this message and had trouble Googling for CLBAS before I realized what it actually meant.