### PR TITLE
[fix] add #include guard to tagger.h

### DIFF
--- a/src/tagger.h
+++ b/src/tagger.h
@@ -1,5 +1,10 @@
+#ifndef TAGGER_H
+#define TAGGER_H
+
 #include "string_utils.h"
 #include "tokens.h"
 
 // Arguments:                           tagger, context, tokenized str,       index
 typedef bool (*tagger_feature_function)(void *, void *, tokenized_string_t *, uint32_t);
+
+#endif


### PR DESCRIPTION
This fixes a build break on CentOS 6, which has gcc 4.4.7. This was tested using the centos/6 Vagrant box (https://atlas.hashicorp.com/centos/boxes/6).

The specific error message was

```
In file included from crf.h:23,
                 from address_parser.h:55,
                 from libpostal.c:10:
tagger.h:5: error: redefinition of typedef ‘tagger_feature_function’
tagger.h:5: note: previous declaration of ‘tagger_feature_function’ was here
```