### PR TITLE
[fix] don't use unnamed fields in initializers

### DIFF
--- a/src/address_parser_train.c
+++ b/src/address_parser_train.c
@@ -783,7 +783,9 @@ address_parser_t *address_parser_init(char *filename) {
         }
 
         if (most_common > -1) {
-            address_parser_types_t types = {.components = stats.components, .most_common = (uint16_t)most_common};
+            address_parser_types_t types;
+            types.components = stats.components;
+            types.most_common = (uint16_t)most_common;
 
             kh_value(phrase_counts, pk) = (uint32_t)phrase_types_array->n;
             address_parser_types_array_push(phrase_types_array, types);

--- a/src/crf_trainer_averaged_perceptron.c
+++ b/src/crf_trainer_averaged_perceptron.c
@@ -220,7 +220,9 @@ static inline bool crf_averaged_perceptron_trainer_update_weight(khash_t(class_w
 static inline bool crf_averaged_perceptron_trainer_update_prev_tag_weight(khash_t(prev_tag_class_weights) *weights, uint64_t iter, uint32_t prev_class_id, uint32_t class_id, double value) {
     class_weight_t weight = NULL_WEIGHT;
 
-    tag_bigram_t tag_bigram = {.prev_class_id = prev_class_id, .class_id = class_id};
+    tag_bigram_t tag_bigram;
+    tag_bigram.prev_class_id = prev_class_id;
+    tag_bigram.class_id = class_id;
 
     uint64_t key = tag_bigram.value;
 


### PR DESCRIPTION
[GCC did not support assigning to unnamed fields from designated initializers until 4.6.](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10676) Unfortunately, CentOS 6 ships with GCC 4.4, so avoiding this C99 feature is necessary to fix building in CentOS 6 environments.

This patch gets things to build, but I'm open to alternative approaches to fixing the build. I'm hoping that the compiler is smart enough to see that this should result in effectively the same assembly code that the previous approach did.