### PR TITLE
Remove ordinal suffixes in libpostal_expand_address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         - secure: "OGNJ6Cj3trq4nASgm4BK331aij+FZ11St7/YF9rfxeQBwg4MCPH2+D0jvAULBHvJR7K2RmepX/FG5d4S+rtwKNGngg3ovPdd1MbwFltHpn5/KM+hxe7kCZx2+V9/FN+4YSyO0zSUDra6AXHOs72mfyrZoB3a36SS4lg2sAp33gU="
         - GH_REF=github.com/openvenues/libpostal
         - DICTIONARIES_CHANGED=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep "resources/dictionaries/.*/*.txt" | wc -l)
-        - NUMEX_CHANGED=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep "resources/numex" | wc -l)
+        - NUMEX_CHANGED=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E "(resources/numex|src/numex_table_builder.c)|" | wc -l)
         - TRANSLIT_CHANGED=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep "src/transliteration_data.c" | wc -l)
 compiler:
     - clang

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ DEFAULT_INCLUDES = -I.. -I/usr/local/include
 CFLAGS =
 
 lib_LTLIBRARIES = libpostal.la
-libpostal_la_SOURCES = libpostal.c address_dictionary.c transliterate.c tokens.c trie.c trie_search.c trie_utils.c string_utils.c file_utils.c numex.c utf8proc/utf8proc.c cmp/cmp.c normalize.c features.c unicode_scripts.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c averaged_perceptron_tagger.c graph.c graph_builder.c language_classifier.c language_features.c logistic_regression.c logistic.c minibatch.c float_utils.c ngrams.c
+libpostal_la_SOURCES = libpostal.c address_dictionary.c transliterate.c tokens.c trie.c trie_search.c trie_utils.c string_utils.c file_utils.c utf8proc/utf8proc.c cmp/cmp.c normalize.c numex.c features.c unicode_scripts.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c averaged_perceptron_tagger.c graph.c graph_builder.c language_classifier.c language_features.c logistic_regression.c logistic.c minibatch.c float_utils.c ngrams.c
 libpostal_la_LIBADD = libscanner.la $(CBLAS_LIBS)
 libpostal_la_CFLAGS = $(CFLAGS_O2)
 libpostal_la_LDFLAGS = -version-info @LIBPOSTAL_SO_VERSION@
@@ -34,7 +34,7 @@ libpostal_CFLAGS = $(CFLAGS_O3)
 bench_SOURCES = bench.c
 bench_LDADD = libpostal.la libscanner.la $(CBLAS_LIBS)
 bench_CFLAGS = $(CFLAGS_O3)
-address_parser_SOURCES = address_parser_cli.c json_encode.c linenoise/linenoise.c libpostal.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_tagger.c address_dictionary.c normalize.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c utf8proc/utf8proc.c ngrams.c numex.c language_classifier.c language_features.c logistic_regression.c logistic.c minibatch.c
+address_parser_SOURCES = address_parser_cli.c json_encode.c linenoise/linenoise.c libpostal.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_tagger.c address_dictionary.c normalize.c numex.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c utf8proc/utf8proc.c ngrams.c language_classifier.c language_features.c logistic_regression.c logistic.c minibatch.c
 address_parser_LDADD = libscanner.la $(CBLAS_LIBS)
 address_parser_CFLAGS = $(CFLAGS_O3)
 
@@ -44,21 +44,21 @@ build_numex_table_SOURCES = numex_table_builder.c numex.c file_utils.c string_ut
 build_numex_table_CFLAGS = $(CFLAGS_O3)
 build_trans_table_SOURCES = transliteration_table_builder.c transliterate.c trie.c trie_search.c file_utils.c string_utils.c utf8proc/utf8proc.c
 build_trans_table_CFLAGS = $(CFLAGS_O3)
-address_parser_train_SOURCES = address_parser_train.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_trainer.c crf_trainer.c crf_trainer_averaged_perceptron.c averaged_perceptron_tagger.c address_dictionary.c normalize.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c shuffle.c utf8proc/utf8proc.c ngrams.c
+address_parser_train_SOURCES = address_parser_train.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_trainer.c crf_trainer.c crf_trainer_averaged_perceptron.c averaged_perceptron_tagger.c address_dictionary.c normalize.c numex.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c shuffle.c utf8proc/utf8proc.c ngrams.c
 address_parser_train_LDADD = libscanner.la $(CBLAS_LIBS)
 address_parser_train_CFLAGS = $(CFLAGS_O3)
 
-address_parser_test_SOURCES = address_parser_test.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_tagger.c address_dictionary.c normalize.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c utf8proc/utf8proc.c ngrams.c
+address_parser_test_SOURCES = address_parser_test.c address_parser.c address_parser_io.c averaged_perceptron.c crf.c crf_context.c sparse_matrix.c graph.c graph_builder.c float_utils.c averaged_perceptron_tagger.c address_dictionary.c normalize.c numex.c features.c unicode_scripts.c transliterate.c trie.c trie_search.c trie_utils.c string_utils.c tokens.c file_utils.c utf8proc/utf8proc.c ngrams.c
 address_parser_test_LDADD = libscanner.la  $(CBLAS_LIBS)
 address_parser_test_CFLAGS = $(CFLAGS_O3)
 
-language_classifier_train_SOURCES = language_classifier_train.c language_classifier.c language_features.c language_classifier_io.c logistic_regression_trainer.c logistic_regression.c logistic.c sparse_matrix.c sparse_matrix_utils.c features.c minibatch.c float_utils.c stochastic_gradient_descent.c ftrl.c regularization.c cartesian_product.c normalize.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c shuffle.c
+language_classifier_train_SOURCES = language_classifier_train.c language_classifier.c language_features.c language_classifier_io.c logistic_regression_trainer.c logistic_regression.c logistic.c sparse_matrix.c sparse_matrix_utils.c features.c minibatch.c float_utils.c stochastic_gradient_descent.c ftrl.c regularization.c cartesian_product.c normalize.c numex.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c shuffle.c
 language_classifier_train_LDADD = libscanner.la $(CBLAS_LIBS)
 language_classifier_train_CFLAGS = $(CFLAGS_O3)
-language_classifier_SOURCES = language_classifier_cli.c language_classifier.c language_features.c logistic_regression.c logistic.c sparse_matrix.c features.c minibatch.c float_utils.c normalize.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c
+language_classifier_SOURCES = language_classifier_cli.c language_classifier.c language_features.c logistic_regression.c logistic.c sparse_matrix.c features.c minibatch.c float_utils.c normalize.c numex.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c
 language_classifier_LDADD = libscanner.la $(CBLAS_LIBS)
 language_classifier_CFLAGS = $(CFLAGS_O3)
-language_classifier_test_SOURCES = language_classifier_test.c language_classifier.c language_classifier_io.c language_features.c logistic_regression.c logistic.c sparse_matrix.c features.c minibatch.c float_utils.c normalize.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c
+language_classifier_test_SOURCES = language_classifier_test.c language_classifier.c language_classifier_io.c language_features.c logistic_regression.c logistic.c sparse_matrix.c features.c minibatch.c float_utils.c normalize.c numex.c transliterate.c trie.c trie_search.c trie_utils.c address_dictionary.c string_utils.c file_utils.c utf8proc/utf8proc.c unicode_scripts.c
 language_classifier_test_LDADD = libscanner.la $(CBLAS_LIBS)
 language_classifier_test_CFLAGS = $(CFLAGS_O3)
 

--- a/src/normalize.h
+++ b/src/normalize.h
@@ -33,6 +33,7 @@ As well as normalizations for individual string tokens:
 #include "string_utils.h"
 #include "utf8proc/utf8proc.h"
 #include "unicode_scripts.h"
+#include "numex.h"
 #include "transliterate.h"
 #include "trie.h"
 #include "tokens.h"
@@ -47,6 +48,7 @@ As well as normalizations for individual string tokens:
 #define NORMALIZE_STRING_REPLACE_HYPHENS 1 << 6
 #define NORMALIZE_STRING_COMPOSE 1 << 7
 #define NORMALIZE_STRING_SIMPLE_LATIN_ASCII 1 << 8
+#define NORMALIZE_STRING_REPLACE_NUMEX 1 << 9
 
 #define NORMALIZE_TOKEN_REPLACE_HYPHENS 1 << 0
 #define NORMALIZE_TOKEN_DELETE_HYPHENS 1 << 1

--- a/src/numex.h
+++ b/src/numex.h
@@ -34,7 +34,8 @@ typedef enum {
     GENDER_MASCULINE,
     GENDER_FEMININE,
     GENDER_NEUTER,
-    GENDER_NONE
+    GENDER_NONE,
+    NUM_GENDERS
 } gender_t;
 
 #define CATEGORY_PLURAL_PREFIX "p"
@@ -42,7 +43,8 @@ typedef enum {
 
 typedef enum {
     CATEGORY_PLURAL,
-    CATEGORY_DEFAULT
+    CATEGORY_DEFAULT,
+    NUM_CATEGORIES
 } grammatical_category_t;
 
 typedef enum {
@@ -85,9 +87,13 @@ typedef struct numex_rule {
 VECTOR_INIT(numex_rule_array, numex_rule_t)
 
 #define ORDINAL_NAMESPACE_CHAR "o"
+#define ORDINAL_PHRASE_NAMESPACE_CHAR "p"
 
 #define ORDINAL_NAMESPACE_PREFIX NAMESPACE_SEPARATOR_CHAR ORDINAL_NAMESPACE_CHAR NAMESPACE_SEPARATOR_CHAR            
 #define ORDINAL_NAMESPACE_PREFIX_LEN strlen(ORDINAL_NAMESPACE_PREFIX)
+
+#define ORDINAL_PHRASE_NAMESPACE_PREFIX NAMESPACE_SEPARATOR_CHAR ORDINAL_PHRASE_NAMESPACE_CHAR NAMESPACE_SEPARATOR_CHAR
+#define ORDINAL_PHRASE_NAMESPACE_PREFIX_LEN strlen(ORDINAL_PHRASE_NAMESPACE_PREFIX)
 
 typedef struct ordinal_indicator {
     char *key;
@@ -142,7 +148,7 @@ VECTOR_INIT(numex_result_array, numex_result_t)
 
 char *replace_numeric_expressions(char *str, char *lang);
 numex_result_array *convert_numeric_expressions(char *str, char *lang);
-char *get_ordinal_suffix(char *numeric_string, char *lang, numex_result_t result);
+size_t ordinal_suffix_len(char *s, size_t len, char *lang);
 
 bool numex_table_write(FILE *file);
 bool numex_table_save(char *filename);

--- a/src/numex_table_builder.c
+++ b/src/numex_table_builder.c
@@ -92,72 +92,84 @@ int main(int argc, char **argv) {
         }
 
         for (j = ordinal_indicator_index; j < ordinal_indicator_index + num_ordinal_indicators; j++) {
-            value = numex_table->ordinal_indicators->n;
-            ordinal_indicator_t ordinal_source = ordinal_indicator_rules[j];
+            for (int ordinal_phrases = 0; ordinal_phrases <= 1; ordinal_phrases++) {
+                value = numex_table->ordinal_indicators->n;
+                ordinal_indicator_t ordinal_source = ordinal_indicator_rules[j];
 
-            if (ordinal_source.key == NULL) {
-                log_error("ordinal source key was NULL at index %d\n", j);
-                exit(EXIT_FAILURE);
-            }
+                if (ordinal_source.key == NULL) {
+                    log_error("ordinal source key was NULL at index %d\n", j);
+                    exit(EXIT_FAILURE);
+                }
 
-            char *ordinal_indicator_key = strdup(ordinal_source.key);
-            if (ordinal_indicator_key == NULL) {
-                log_error("Error in strdup\n");
-                exit(EXIT_FAILURE);
-            }
-
-            char *suffix = NULL;
-            if (ordinal_source.suffix != NULL) {
-                suffix = strdup(ordinal_source.suffix);
-                if (suffix == NULL) {
+                char *ordinal_indicator_key = strdup(ordinal_source.key);
+                if (ordinal_indicator_key == NULL) {
                     log_error("Error in strdup\n");
                     exit(EXIT_FAILURE);
                 }
-            }
-            ordinal_indicator_t *ordinal = ordinal_indicator_new(ordinal_indicator_key, ordinal_source.gender, ordinal_source.category, suffix);
-            ordinal_indicator_array_push(numex_table->ordinal_indicators, ordinal);            
 
-            char_array_clear(key);
-            char_array_cat(key, lang);
-            char_array_cat(key, ORDINAL_NAMESPACE_PREFIX);
+                char *suffix = NULL;
+                if (ordinal_source.suffix != NULL) {
+                    suffix = strdup(ordinal_source.suffix);
+                    if (suffix == NULL) {
+                        log_error("Error in strdup\n");
+                        exit(EXIT_FAILURE);
+                    }
+                }
 
-            switch (ordinal_source.gender) {
-                case GENDER_MASCULINE:
-                    char_array_cat(key, GENDER_MASCULINE_PREFIX);
-                    break;
-                case GENDER_FEMININE:
-                    char_array_cat(key, GENDER_FEMININE_PREFIX);
-                    break;
-                case GENDER_NEUTER:
-                    char_array_cat(key, GENDER_NEUTER_PREFIX);
-                    break;
-                case GENDER_NONE:
-                default:
-                    char_array_cat(key, GENDER_NONE_PREFIX);
-            }
+                char_array_clear(key);
+                char_array_cat(key, lang);
 
-            switch (ordinal_source.category) {
-                case CATEGORY_PLURAL:
-                    char_array_cat(key, CATEGORY_PLURAL_PREFIX);
-                    break;
-                case CATEGORY_DEFAULT:
-                default:
-                    char_array_cat(key, CATEGORY_DEFAULT_PREFIX);
+                if (!ordinal_phrases) {
+                    ordinal_indicator_t *ordinal = ordinal_indicator_new(ordinal_indicator_key, ordinal_source.gender, ordinal_source.category, suffix);
+                    ordinal_indicator_array_push(numex_table->ordinal_indicators, ordinal);            
 
-            }
+                    char_array_cat(key, ORDINAL_NAMESPACE_PREFIX);
+                } else {
+                    char_array_cat(key, ORDINAL_PHRASE_NAMESPACE_PREFIX);
+                }
 
-            char_array_cat(key, NAMESPACE_SEPARATOR_CHAR);
+                switch (ordinal_source.gender) {
+                    case GENDER_MASCULINE:
+                        char_array_cat(key, GENDER_MASCULINE_PREFIX);
+                        break;
+                    case GENDER_FEMININE:
+                        char_array_cat(key, GENDER_FEMININE_PREFIX);
+                        break;
+                    case GENDER_NEUTER:
+                        char_array_cat(key, GENDER_NEUTER_PREFIX);
+                        break;
+                    case GENDER_NONE:
+                    default:
+                        char_array_cat(key, GENDER_NONE_PREFIX);
+                }
 
-            char *reversed = utf8_reversed_string(ordinal_source.key);
-            char_array_cat(key, reversed);
-            free(reversed);
+                switch (ordinal_source.category) {
+                    case CATEGORY_PLURAL:
+                        char_array_cat(key, CATEGORY_PLURAL_PREFIX);
+                        break;
+                    case CATEGORY_DEFAULT:
+                    default:
+                        char_array_cat(key, CATEGORY_DEFAULT_PREFIX);
 
-            char *str_key = char_array_get_string(key);
+                }
 
-            if (trie_get(numex_table->trie, str_key) == NULL_NODE_ID) {
-                trie_add(numex_table->trie, str_key, value);
-            } else {
-                log_warn("Key exists: %s, skipping\n", str_key);                            
+                char_array_cat(key, NAMESPACE_SEPARATOR_CHAR);
+
+                char *key_str = ordinal_source.key;
+
+                if (ordinal_phrases) {
+                    key_str = suffix;
+                }
+
+                char *reversed = utf8_reversed_string(key_str);
+                char_array_cat(key, reversed);
+                free(reversed);
+
+                char *str_key = char_array_get_string(key);
+
+                if (trie_get(numex_table->trie, str_key) == NULL_NODE_ID) {
+                    trie_add(numex_table->trie, str_key, value);
+                }
             }
         }
 


### PR DESCRIPTION
In some address data sets, it's common to see things like "E 96 St" instead of "E 96th St" as might appear on a street sign.

We have ordinal suffixes in libpostal's numeric expression configs, but so far they've only been used to add the correct suffix when parsing ordinal expressions like "One hundred twenty-third". Using the rule sets, we can get to the number "123". For ordinals, we then have a trie that maps final digits to their correct suffix ("3" => "rd" unless preceded by a "1" such that "13" => "th").

This PR adds another type of trie entry to the numex table which allows us to look up whether the current token is an ordinal (digits + a valid suffix in the language/s being considered). We can then add a form of the string to the expansions with the ordinal suffix removed. This is in addition to the form with the suffix intact. So ```./libpostal "One twenty-third"``` returns *both* "123rd" and "123".

With this change, addresses written with/without the ordinal suffixes will all share a common normalization for all the languages covered by the [numex configs](https://github.com/openvenues/libpostal/tree/master/resources/numex), including different genders of ordinals e.g. "1º" and "1ª" in Spanish/Italian. If there are patterns not being handled correctly, it's possible to add alternative forms to the configs.

There's one form that's currently not handled and may take a little more work, which is a Roman numeral with an ordinal suffix (have only really seen it in French e.g. "IXe Arrondissement" though this seems to be less common than "9e Arrondissement")