### PR TITLE
Fix log_{debug,info} formats which expect size_t but receive int.

### DIFF
--- a/src/trie_search.c
+++ b/src/trie_search.c
@@ -356,7 +356,7 @@ bool trie_search_tokens_from_index(trie_t *self, char *str, token_array *tokens,
 
                 // Note: i gets incremented with the next iteration of the for loop
                 i = phrase_start;
-                log_debug("last_state == SEARCH_STATE_PARTIAL_MATCH, i = %zu\n", i);
+                log_debug("last_state == SEARCH_STATE_PARTIAL_MATCH, i = %d\n", i);
                 last_match_index = -1;
                 phrase_start = phrase_len = 0;
                 node_id = last_node_id = start_node_id;

--- a/src/trie_utils.c
+++ b/src/trie_utils.c
@@ -41,7 +41,7 @@ trie_t *trie_new_from_hash(khash_t(str_uint32) *hash) {
             return NULL;
         }
         if (i % 100000 == 0 && i > 0) {
-            log_info("added %zu keys to trie\n", i);
+            log_info("added %d keys to trie\n", i);
         }
     }
 


### PR DESCRIPTION
Hi - a little more cleanup of log_{debug,info} messages.