### PR TITLE
Add Elixir language binding to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Libpostal is designed to be used by higher-level languages.  If you don't see yo
 
 - LuaJIT: [lua-resty-postal](https://github.com/bungle/lua-resty-postal)
 - Perl: [Geo::libpostal](https://metacpan.org/pod/Geo::libpostal)
+- Elixir: [Expostal](https://github.com/SweetIQ/expostal)
 
 **Database extensions**
 


### PR DESCRIPTION
Hi maintainers,

We recently opensourced a [Elixir binding for libpostal](https://github.com/SweetIQ/expostal). The binding is well documented and tested against libpostal master branch. Hoping to add this to the project README for better visibility.
