### PR TITLE
32-bit safety in numex table loading

### DIFF
--- a/src/numex.c
+++ b/src/numex.c
@@ -227,33 +227,47 @@ static bool numex_language_write(numex_language_t *language, FILE *f) {
 }
 
 static bool numex_rule_read(FILE *f, numex_rule_t *rule) {
-    if (!file_read_uint64(f, (uint64_t *)&rule->left_context_type)) {
+    uint64_t left_context_type;
+    if (!file_read_uint64(f, &left_context_type)) {
         return false;
     }
+    rule->left_context_type = left_context_type;
 
-    if (!file_read_uint64(f, (uint64_t *)&rule->right_context_type)) {
+    uint64_t right_context_type;
+    if (!file_read_uint64(f, &right_context_type)) {
         return false;
     }
+    rule->right_context_type = right_context_type;
 
-    if (!file_read_uint64(f, (uint64_t *)&rule->rule_type)) {
+    uint64_t rule_type;
+    if (!file_read_uint64(f, &rule_type)) {
         return false;
     }
+    rule->rule_type = rule_type;
 
-    if (!file_read_uint64(f, (uint64_t *)&rule->gender)) {
+    uint64_t gender;
+    if (!file_read_uint64(f, &gender)) {
         return false;
     }
+    rule->gender = gender;
 
-    if (!file_read_uint64(f, (uint64_t *)&rule->category)) {
+    uint64_t category;
+    if (!file_read_uint64(f, &category)) {
         return false;
     }
+    rule->category = category;
 
-    if (!file_read_uint32(f, &rule->radix)) {
+    uint32_t radix;
+    if (!file_read_uint32(f, &radix)) {
         return false;
     }
+    rule->radix = radix;
 
-    if (!file_read_uint64(f, (uint64_t *)&rule->value)) {
+    uint64_t value;
+    if (!file_read_uint64(f, &value)) {
         return false;
     }
+    rule->value = value;
 
     return true;
 }
@@ -343,15 +357,17 @@ static ordinal_indicator_t *ordinal_indicator_read(FILE *f) {
         return NULL;
     }
 
-    gender_t gender;
-    if (!file_read_uint64(f, (uint64_t *)&gender)) {
+    uint64_t gender_uint64;
+    if (!file_read_uint64(f, &gender_uint64)) {
         return NULL;
     }
+    gender_t gender = gender_uint64;
 
-    grammatical_category_t category;
-    if (!file_read_uint64(f, (uint64_t *)&category)) {
+    uint64_t category_uint64;
+    if (!file_read_uint64(f, &category_uint64)) {
         return NULL;
     }
+    grammatical_category_t category = category_uint64;
 
     uint64_t ordinal_suffix_len;
     if (!file_read_uint64(f, &ordinal_suffix_len)) {


### PR DESCRIPTION
There are a few more cases that can smash the stack on 32-bit machines when reading 64-bit ints into `enum` types in numex.c. Reading the on-disk values into a local uint64, then casting.