### PR TITLE
Changes front matter of iis.yaml to correct description

### DIFF
--- a/resources/addresses/is.yaml
+++ b/resources/addresses/is.yaml
@@ -1,6 +1,6 @@
-# da.yaml
+# is.yaml
 # -------
-# Danish language specification.
+# Icelandic language specification.
 
 components:
     level:


### PR DESCRIPTION
The front matter of the is.yaml says it is the danish description, but it is not. It is the icelandic description.