### PR TITLE
Add configure check for drand48 and only compile function if missing.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_TYPE_UINT8_T
 AC_CHECK_TYPES([ptrdiff_t])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([malloc realloc getcwd gettimeofday memmove memset regcomp setlocale sqrt strdup strndup])
+AC_CHECK_FUNCS([malloc realloc getcwd gettimeofday memmove memset regcomp setlocale sqrt strdup strndup drand48])
 
 AC_CONFIG_FILES([Makefile
                  libpostal.pc

--- a/src/klib/drand48.c
+++ b/src/klib/drand48.c
@@ -1,3 +1,5 @@
+#include <config.h>
+#ifndef HAVE_DRAND48
 
 /*
  * Copyright (c) 1993 Martin Birgmeier
@@ -17,54 +19,56 @@
 #include <math.h>
 #include "drand48.h"
 
-#define	RAND48_SEED_0	(0x330e)
-#define	RAND48_SEED_1	(0xabcd)
-#define	RAND48_SEED_2	(0x1234)
-#define	RAND48_MULT_0	(0xe66d)
-#define	RAND48_MULT_1	(0xdeec)
-#define	RAND48_MULT_2	(0x0005)
-#define	RAND48_ADD	    (0x000b)
+#define RAND48_SEED_0 (0x330e)
+#define RAND48_SEED_1 (0xabcd)
+#define RAND48_SEED_2 (0x1234)
+#define RAND48_MULT_0 (0xe66d)
+#define RAND48_MULT_1 (0xdeec)
+#define RAND48_MULT_2 (0x0005)
+#define RAND48_ADD    (0x000b)
 
 unsigned short _rand48_seed[3] = {
-	RAND48_SEED_0,
-	RAND48_SEED_1,
-	RAND48_SEED_2
+    RAND48_SEED_0,
+    RAND48_SEED_1,
+    RAND48_SEED_2
 };
 
 unsigned short _rand48_mult[3] = {
-	RAND48_MULT_0,
-	RAND48_MULT_1,
-	RAND48_MULT_2
+    RAND48_MULT_0,
+    RAND48_MULT_1,
+    RAND48_MULT_2
 };
 
 unsigned short _rand48_add = RAND48_ADD;
 
 void _dorand48(unsigned short xseed[3])
 {
-	unsigned long accu;
-	unsigned short temp[2];
+    unsigned long accu;
+    unsigned short temp[2];
 
-	accu = (unsigned long) _rand48_mult[0] * (unsigned long) xseed[0] + (unsigned long) _rand48_add;
-	temp[0] = (unsigned short) accu;	/* lower 16 bits */
-	accu >>= sizeof(unsigned short) * 8;
-	accu += (unsigned long) _rand48_mult[0] * (unsigned long) xseed[1] + (unsigned long) _rand48_mult[1] * (unsigned long) xseed[0];
-	temp[1] = (unsigned short) accu;	/* middle 16 bits */
-	accu >>= sizeof(unsigned short) * 8;
-	accu += _rand48_mult[0] * xseed[2] + _rand48_mult[1] * xseed[1] + _rand48_mult[2] * xseed[0];
-	xseed[0] = temp[0];
-	xseed[1] = temp[1];
-	xseed[2] = (unsigned short) accu;
+    accu = (unsigned long) _rand48_mult[0] * (unsigned long) xseed[0] + (unsigned long) _rand48_add;
+    temp[0] = (unsigned short) accu;    /* lower 16 bits */
+    accu >>= sizeof(unsigned short) * 8;
+    accu += (unsigned long) _rand48_mult[0] * (unsigned long) xseed[1] + (unsigned long) _rand48_mult[1] * (unsigned long) xseed[0];
+    temp[1] = (unsigned short) accu;    /* middle 16 bits */
+    accu >>= sizeof(unsigned short) * 8;
+    accu += _rand48_mult[0] * xseed[2] + _rand48_mult[1] * xseed[1] + _rand48_mult[2] * xseed[0];
+    xseed[0] = temp[0];
+    xseed[1] = temp[1];
+    xseed[2] = (unsigned short) accu;
 }
 
 double erand48(unsigned short xseed[3])
 {
-	_dorand48(xseed);
-	return ldexp((double) xseed[0], -48) +
-	       ldexp((double) xseed[1], -32) +
-	       ldexp((double) xseed[2], -16);
+    _dorand48(xseed);
+    return ldexp((double) xseed[0], -48) +
+           ldexp((double) xseed[1], -32) +
+           ldexp((double) xseed[2], -16);
 }
 
 double drand48(void)
 {
-	return erand48(_rand48_seed);
+    return erand48(_rand48_seed);
 }
+
+#endif // HAVE_DRAND48

--- a/src/klib/drand48.h
+++ b/src/klib/drand48.h
@@ -17,13 +17,17 @@
 #ifndef _DRAND48_H
 #define _DRAND48_H
 
-#define	RAND48_SEED_0	(0x330e)
-#define	RAND48_SEED_1	(0xabcd)
-#define	RAND48_SEED_2	(0x1234)
-#define	RAND48_MULT_0	(0xe66d)
-#define	RAND48_MULT_1	(0xdeec)
-#define	RAND48_MULT_2	(0x0005)
-#define	RAND48_ADD	    (0x000b)
+#include <config.h>
+
+#ifndef HAVE_DRAND48
+
+#define	RAND48_SEED_0 (0x330e)
+#define	RAND48_SEED_1 (0xabcd)
+#define	RAND48_SEED_2 (0x1234)
+#define	RAND48_MULT_0 (0xe66d)
+#define	RAND48_MULT_1 (0xdeec)
+#define	RAND48_MULT_2 (0x0005)
+#define	RAND48_ADD    (0x000b)
 
 unsigned short _rand48_seed[3];
 
@@ -37,5 +41,5 @@ double erand48(unsigned short xseed[3]);
 
 double drand48(void);
 
-
-#endif  // _DRAND48_H
+#endif // HAVE_DRAND48
+#endif // _DRAND48_H


### PR DESCRIPTION
There is an issue with compiling on Mac with the new `drand48.c` & `drand48.h` files added by the Windows patch.  I have added a check to the configure script so that these are only used if a system version is not available.