### PR TITLE
Fix leak of normalized value in early return

### DIFF
--- a/src/address_parser.c
+++ b/src/address_parser.c
@@ -1770,6 +1770,10 @@ libpostal_address_parser_response_t *address_parser_parse(char *address, char *l
 
             token_array_destroy(tokens);
             tokenized_string_destroy(tokenized_str);
+
+            if (is_normalized) {
+                free(normalized);
+            }
             return response;
         }
     }


### PR DESCRIPTION
This leak can be reproduced with:

```c
    libpostal_address_parser_options_t options = { .country = "US", .language = "en"};
    libpostal_address_parser_response_t *parsed = libpostal_parse_address("foo", options);
    libpostal_address_parser_response_destroy(parsed);
```
The normalized value was not freed before an early return.

Here was the relevant output from Valgrind before the fix:

```
==17267== 4 bytes in 1 blocks are definitely lost in loss record 1 of 279
==17267==    at 0x4C31D2F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17267==    by 0x146897: utf8proc_map (utf8proc.c:608)
==17267==    by 0x146B3D: normalize_string_utf8_languages (normalize.c:69)
==17267==    by 0x146D4C: normalize_string_latin_languages (normalize.c:128)
==17267==    by 0x14FD8A: address_parser_normalize_string (address_parser.c:355)
==17267==    by 0x14FD8A: address_parser_parse (address_parser.c:1665)
==17267==    by 0x132BB5: libpostal_parse_address (libpostal.c:1065)
```