### PR TITLE
Fix typo in python imports

### DIFF
--- a/scripts/geodata/polygons/reverse_geocode.py
+++ b/scripts/geodata/polygons/reverse_geocode.py
@@ -28,7 +28,7 @@ this_dir = os.path.realpath(os.path.dirname(__file__))
 sys.path.append(os.path.realpath(os.path.join(os.pardir, os.pardir)))
 
 from geodata.coordinates.conversion import latlon_to_decimal
-from goedata.countries.constants import Countries
+from geodata.countries.constants import Countries
 from geodata.encoding import safe_decode
 from geodata.file_utils import ensure_dir, download_file
 from geodata.i18n.unicode_properties import get_chars_by_script


### PR DESCRIPTION
Hi,

I corrected a small typo that made the python script impossible to run.

I'll use this PR to ask a question.

I want to create an easier way to use the osm administrative regions. I'm trying to create a admin hierarchy a bit like WoF but based only on OSM (and maybe quattroshapes) , with typed zones that depends on each other (I've described this in [a repo](https://github.com/QwantResearch/cosmogony))

When I found libpostal python scripts I though they would be a perfect starting point, but I find those very difficult to use.

Are those scripts still used ?

Do you have some documentation or code on how you use the scripts to generate the training dataset ?
I'm a bit lost on which script I need to call and with which parameters (and I have some small problems like this PR when running some scrips).

Thanks for the wonderful libpostal project :+1: , when digging into the python scripts I realize whole depth of complexity I would never have imagined :scream: 