### PR TITLE
fix memory leak in setup when datadir is invalid or setup failed

### DIFF
--- a/src/libpostal.c
+++ b/src/libpostal.c
@@ -261,20 +261,22 @@ bool libpostal_setup_datadir(char *datadir) {
         numex_path = path_join(3, datadir, LIBPOSTAL_NUMEX_SUBDIR, NUMEX_DATA_FILE);
         address_dictionary_path = path_join(3, datadir, LIBPOSTAL_ADDRESS_EXPANSIONS_SUBDIR, ADDRESS_DICTIONARY_DATA_FILE);
     }
+    
+    bool setup_succeed = true;
 
     if (!transliteration_module_setup(transliteration_path)) {
         log_error("Error loading transliteration module, dir=%s\n", transliteration_path);
-        return false;
+        setup_succeed = false;
     }
 
-    if (!numex_module_setup(numex_path)) {
+    if (setup_succeed && !numex_module_setup(numex_path)) {
         log_error("Error loading numex module, dir=%s\n", numex_path);
-        return false;
+        setup_succeed = false;
     }
 
-    if (!address_dictionary_module_setup(address_dictionary_path)) {
+    if (setup_succeed && !address_dictionary_module_setup(address_dictionary_path)) {
         log_error("Error loading dictionary module, dir=%s\n", address_dictionary_path);
-        return false;
+        setup_succeed = false;
     }
 
     if (transliteration_path != NULL) {
@@ -289,7 +291,7 @@ bool libpostal_setup_datadir(char *datadir) {
         free(address_dictionary_path);
     }
 
-    return true;
+    return setup_succeed;
 }
 
 bool libpostal_setup(void) {


### PR DESCRIPTION
I found this leak when passing an invalid datadir to setup. I'm running on 1.0.0 but it seems this issue still exists on master:

```
ERR   Error loading transliteration module, dir=/fake/datadir/transliteration/transliteration.dat
   at libpostal_setup_datadir (libpostal.c:1047) errno: No such file or directory
WARNING: Logging before InitGoogleLogging() is written to STDERR
ERR   parser is not setup, call libpostal_setup_address_parser()
   at address_parser_parse (address_parser.c:1659) errno: No such file or directory
ERR   Parser returned NULL
   at libpostal_parse_address (libpostal.c:1027) errno: No such file or directory

=================================================================
==4194251==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x4f7e90 in realloc (/data/users/jdedward/libpostal_wrapper_test+0x4f7e90)
    #1 0x7f3c6803b929 in char_array_push /home/libpostal/1.0.0/src/libpostal-1.0.0/src/collections.h:50
    #2 0x7f3c6803b929 in char_array_append_len /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:673
    #3 0x7f3c6803b929 in char_array_add_vjoined /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:757
    #4 0x7f3c6803db58 in path_vjoin /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:49
    #5 0x7f3c6803dc0a in path_join /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:56
    #6 0x7f3c6802a393 in libpostal_setup_datadir /home/libpostal/1.0.0/src/libpostal-1.0.0/src/libpostal.c:1042
...

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x4f7e90 in realloc (/data/users/jdedward/libpostal_wrapper_test+0x4f7e90)
    #1 0x7f3c6803b929 in char_array_push /home/libpostal/1.0.0/src/libpostal-1.0.0/src/collections.h:50
    #2 0x7f3c6803b929 in char_array_append_len /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:673
    #3 0x7f3c6803b929 in char_array_add_vjoined /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:757
    #4 0x7f3c6803db58 in path_vjoin /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:49
    #5 0x7f3c6803dc0a in path_join /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:56
    #6 0x7f3c6802a3b3 in libpostal_setup_datadir /home/libpostal/1.0.0/src/libpostal-1.0.0/src/libpostal.c:1043
...

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x4f7e90 in realloc (/data/users/jdedward/libpostal_wrapper_test+0x4f7e90)
    #1 0x7f3c6803b929 in char_array_push /home/libpostal/1.0.0/src/libpostal-1.0.0/src/collections.h:50
    #2 0x7f3c6803b929 in char_array_append_len /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:673
    #3 0x7f3c6803b929 in char_array_add_vjoined /home/libpostal/1.0.0/src/libpostal-1.0.0/src/string_utils.c:757
    #4 0x7f3c6803db58 in path_vjoin /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:49
    #5 0x7f3c6803dc0a in path_join /home/libpostal/1.0.0/src/libpostal-1.0.0/src/file_utils.c:56
    #6 0x7f3c6802a373 in libpostal_setup_datadir /home/libpostal/1.0.0/src/libpostal-1.0.0/src/libpostal.c:1041
...
```