### PR TITLE
[fix] avoid UB due to signed overflow in left shift

### DIFF
--- a/src/file_utils.c
+++ b/src/file_utils.c
@@ -198,7 +198,7 @@ bool file_write_float(FILE *file, float value) {
 }
 
 inline uint32_t file_deserialize_uint32(unsigned char *buf) {
-    return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+    return ((uint32_t)buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
 }
 
 bool file_read_uint32(FILE *file, uint32_t *value) {


### PR DESCRIPTION
The left shift of the unsigned char value in `file_deserialize_uint32`, which is promoted to int (instead of unsigned int), can lead to a signed overflow and thus undefined behavior.

Adding a cast to `uint32_t` (similarly to what is already done in the 64-bit version of the function) is enough to prevent it.

The issue was found with Frama-C/Eva, and I also confirmed it by extracting and compiling the following code with `clang -fsanitize=undefined`:

```
#include <stdbool.h>
#include <stdint.h>
#include <stdio.h>

uint32_t file_deserialize_uint32(unsigned char *buf) {
  return (buf[0] << 24) | (buf[1] << 16U) | (buf[2] << 8U) | buf[3];
}

bool file_read_uint32(FILE *file, uint32_t *value) {
    unsigned char buf[4];
    if (fread(buf, 4, 1, file) == 1) {
        *value = file_deserialize_uint32(buf);
        return true;
    }
    return false;
}

int main() {
  uint32_t signature;
  FILE *f = fopen("/tmp/a.txt", "rb");
  file_read_uint32(f, &signature);
}
```

Running this code (with a suitable `/tmp/a.txt`, containing e.g. `0xAAAAAAAA`) results in the following message emitted by Clang's sanitizer:

`test.c:6:18: runtime error: left shift of 170 by 24 places cannot be represented in type 'int'`

Adding the cast to `uint32_t`, as in the proposed patch, removes the warning.