### PR TITLE
whosonfirst neighbourhood reverse geocoder

### DIFF
--- a/scripts/geodata/polygons/index.py
+++ b/scripts/geodata/polygons/index.py
@@ -226,7 +226,6 @@ class PolygonIndex(object):
     @classmethod
     def create_from_geojson_files(cls, inputs, output_dir,
                                   index_filename=None,
-                                  polys_filename=DEFAULT_POLYS_FILENAME,
                                   include_only_properties=None):
         index = cls(save_dir=output_dir, index_filename=index_filename or cls.INDEX_FILENAME)
         for input_file in inputs:

--- a/scripts/geodata/whosonfirst/download_wof_admin_polygon.py
+++ b/scripts/geodata/whosonfirst/download_wof_admin_polygon.py
@@ -1,0 +1,27 @@
+import os
+import pycountry
+import subprocess
+import sys
+
+
+this_dir = os.path.realpath(os.path.dirname(__file__))
+sys.path.append(os.path.realpath(os.path.join(os.pardir, os.pardir)))
+
+
+WOF_DATA_ADMIN_REPO_URL_PREFIX = "https://github.com/whosonfirst-data/whosonfirst-data/"
+WOF_DATA_ADMIN_REPO_PREFIX = "whosonfirst-data-admin-"
+
+
+def download_wof_data_admin(wof_dir):
+    for country_object in pycountry.countries:
+        repo_name = WOF_DATA_ADMIN_REPO_PREFIX + country_object.alpha2.lower()
+        repo_location = os.path.join(wof_dir, repo_name)
+        if not os.path.exists(repo_location):
+            subprocess.call(["git", "clone", WOF_DATA_ADMIN_REPO_URL_PREFIX + repo_name])
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        sys.exit('Usage: python download_whosonfirst_data.py wof_dir')
+
+    download_wof_data_admin(sys.argv[1])


### PR DESCRIPTION
- replace quattroshapes polygons with whosonfirst polygons (as the quattroshapes files are no longer available, and the author points queriers to whosonfirst, see https://github.com/foursquare/quattroshapes/issues/10)