### PR TITLE
Add rustpostal to unofficial bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Libpostal is designed to be used by higher-level languages.  If you don't see yo
 - LuaJIT: [lua-resty-postal](https://github.com/bungle/lua-resty-postal)
 - Perl: [Geo::libpostal](https://metacpan.org/pod/Geo::libpostal)
 - Elixir: [Expostal](https://github.com/SweetIQ/expostal)
+- Rust: [rustpostal](https://crates.io/crates/rustpostal)
 
 **Database extensions**
 


### PR DESCRIPTION
Adds a link to the Rust bindings I have been working on. See more [here](https://github.com/kodemartin/rustpostal).