### PR TITLE
Check HAVE_CONFIG_H in matrix.h

### DIFF
--- a/src/matrix.h
+++ b/src/matrix.h
@@ -6,7 +6,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef HAVE_CONFIG_H
 #include <config.h>
+#endif
 
 #include "collections.h"
 #include "file_utils.h"


### PR DESCRIPTION
I'm building libpostal in an environment without autotools, and it's been very helpful that I can just pass the necessary `-D` flags to avoid needing an autoconf-generated `config.h`. However, this check wasn't applied in `matrix.h`.