### PR TITLE
build instructions for M1 macs (see #551)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ brew install curl autoconf automake libtool pkg-config
 
 Then to install the C library:
 
+If you're using an M1 Mac, add `--disable-sse2` to the `./configure` command. This will result in poorer performance but the build will succeed.
+
 ```
 git clone https://github.com/openvenues/libpostal
 cd libpostal


### PR DESCRIPTION
M1 Macs don't support x86/Intel SSE2 instructions (see #551). This adds the workaround to get libpostal to build to the README.