### PR TITLE
Option to disable street name expansion for near dupes

### DIFF
--- a/src/libpostal.c
+++ b/src/libpostal.c
@@ -40,7 +40,8 @@ static libpostal_normalize_options_t LIBPOSTAL_DEFAULT_OPTIONS = {
         .drop_english_possessives = true,
         .delete_apostrophes = true,
         .expand_numex = true,
-        .roman_numerals = true
+        .roman_numerals = true,
+        .root = true
 };
 
 libpostal_normalize_options_t libpostal_get_default_options(void) {
@@ -78,7 +79,8 @@ static libpostal_near_dupe_hash_options_t LIBPOSTAL_NEAR_DUPE_HASH_DEFAULT_OPTIO
     .geohash_precision = DEFAULT_NEAR_DUPE_GEOHASH_PRECISION,
     .name_and_address_keys = true,
     .name_only_keys = false,
-    .address_only_keys = false
+    .address_only_keys = false,
+    .root = true
 };
 
 libpostal_near_dupe_hash_options_t libpostal_get_near_dupe_hash_default_options(void) {

--- a/src/libpostal.c
+++ b/src/libpostal.c
@@ -80,7 +80,7 @@ static libpostal_near_dupe_hash_options_t LIBPOSTAL_NEAR_DUPE_HASH_DEFAULT_OPTIO
     .name_and_address_keys = true,
     .name_only_keys = false,
     .address_only_keys = false,
-    .root = true
+    .street_root = true
 };
 
 libpostal_near_dupe_hash_options_t libpostal_get_near_dupe_hash_default_options(void) {

--- a/src/libpostal.h
+++ b/src/libpostal.h
@@ -205,7 +205,7 @@ typedef struct libpostal_near_dupe_hash_options {
     bool name_and_address_keys;
     bool name_only_keys;
     bool address_only_keys;
-    bool root;
+    bool street_root;
 } libpostal_near_dupe_hash_options_t;
 
 LIBPOSTAL_EXPORT libpostal_near_dupe_hash_options_t libpostal_get_near_dupe_hash_default_options(void);

--- a/src/libpostal.h
+++ b/src/libpostal.h
@@ -85,7 +85,7 @@ typedef enum {
 } libpostal_token_type_t;
 
 
-/* 
+/*
 Address dictionaries
 */
 // Bit set, should be able to keep it at a short (uint16_t)
@@ -109,7 +109,7 @@ Address dictionaries
 
 typedef struct libpostal_normalize_options {
     // List of language codes
-    char **languages;  
+    char **languages;
     size_t num_languages;
     uint16_t address_components;
 
@@ -132,6 +132,9 @@ typedef struct libpostal_normalize_options {
     bool delete_apostrophes;
     bool expand_numex;
     bool roman_numerals;
+
+    // Sxpansion options
+    bool root;
 
 } libpostal_normalize_options_t;
 
@@ -202,6 +205,7 @@ typedef struct libpostal_near_dupe_hash_options {
     bool name_and_address_keys;
     bool name_only_keys;
     bool address_only_keys;
+    bool root;
 } libpostal_near_dupe_hash_options_t;
 
 

--- a/src/libpostal.h
+++ b/src/libpostal.h
@@ -85,7 +85,7 @@ typedef enum {
 } libpostal_token_type_t;
 
 
-/*
+/* 
 Address dictionaries
 */
 // Bit set, should be able to keep it at a short (uint16_t)
@@ -109,7 +109,7 @@ Address dictionaries
 
 typedef struct libpostal_normalize_options {
     // List of language codes
-    char **languages;
+    char **languages;  
     size_t num_languages;
     uint16_t address_components;
 
@@ -133,7 +133,7 @@ typedef struct libpostal_normalize_options {
     bool expand_numex;
     bool roman_numerals;
 
-    // Sxpansion options
+    // Expansion options
     bool root;
 
 } libpostal_normalize_options_t;

--- a/src/near_dupe.c
+++ b/src/near_dupe.c
@@ -203,7 +203,7 @@ cstring_array *expanded_component_combined(char *input, libpostal_normalize_opti
         cstring_array_destroy(expansions);
 
         return all_expansions;
-    }
+    }       
 }
 
 static inline cstring_array *expanded_component_root_with_fallback(char *input, libpostal_normalize_options_t options, size_t *n) {
@@ -400,7 +400,7 @@ cstring_array *name_word_hashes(char *name, libpostal_normalize_options_t normal
                 } else {
                     add_string_to_array_if_unique(token_str, strings, unique_strings);
                 }
-            }
+            } 
 
             prev_token = token;
         }
@@ -519,7 +519,7 @@ cstring_array *name_word_hashes(char *name, libpostal_normalize_options_t normal
                             last_was_stopword = is_stopword;
                         }
                         last_was_punctuation = false;
-                    }
+                    } 
                 } else if (is_punct) {
                     log_debug("punctuation\n");
                     last_was_punctuation = true;

--- a/src/near_dupe.c
+++ b/src/near_dupe.c
@@ -150,8 +150,8 @@ cstring_array *expanded_component_combined(char *input, libpostal_normalize_opti
 
     size_t num_root_expansions = 0;
     cstring_array *root_expansions = expand_address_root(input, options, &num_root_expansions);
-    
-    if (num_root_expansions == 0) {
+
+    if (!options.root || num_root_expansions == 0) {
         cstring_array_destroy(root_expansions);
         *n = num_expansions;
         return expansions;
@@ -203,7 +203,7 @@ cstring_array *expanded_component_combined(char *input, libpostal_normalize_opti
         cstring_array_destroy(expansions);
 
         return all_expansions;
-    }       
+    }
 }
 
 static inline cstring_array *expanded_component_root_with_fallback(char *input, libpostal_normalize_options_t options, size_t *n) {
@@ -399,7 +399,7 @@ cstring_array *name_word_hashes(char *name, libpostal_normalize_options_t normal
                 } else {
                     add_string_to_array_if_unique(token_str, strings, unique_strings);
                 }
-            } 
+            }
 
             prev_token = token;
         }
@@ -518,7 +518,7 @@ cstring_array *name_word_hashes(char *name, libpostal_normalize_options_t normal
                             last_was_stopword = is_stopword;
                         }
                         last_was_punctuation = false;
-                    } 
+                    }
                 } else if (is_punct) {
                     log_debug("punctuation\n");
                     last_was_punctuation = true;
@@ -670,6 +670,8 @@ cstring_array *near_dupe_hashes_languages(size_t num_components, char **labels, 
     libpostal_normalize_options_t normalize_options = libpostal_get_default_options();
 
     language_classifier_response_t *lang_response = NULL;
+
+    normalize_options.root = options.root;
 
     if (num_languages == 0) {
         lang_response = place_languages(num_components, labels, values);

--- a/src/near_dupe.c
+++ b/src/near_dupe.c
@@ -671,8 +671,6 @@ cstring_array *near_dupe_hashes_languages(size_t num_components, char **labels, 
 
     language_classifier_response_t *lang_response = NULL;
 
-    normalize_options.root = options.root;
-
     if (num_languages == 0) {
         lang_response = place_languages(num_components, labels, values);
 
@@ -707,6 +705,7 @@ cstring_array *near_dupe_hashes_languages(size_t num_components, char **labels, 
         remove_spaces = true;
         log_debug("Doing street expansions for %s\n", place->street);
         normalize_options.address_components = LIBPOSTAL_ADDRESS_STREET | LIBPOSTAL_ADDRESS_ANY;
+        normalize_options.root = options.root;
         street_expansions = expanded_component_combined(place->street, normalize_options, remove_spaces, &num_street_expansions);
         log_debug("Got %zu street expansions\n", num_street_expansions);
     }

--- a/src/near_dupe.c
+++ b/src/near_dupe.c
@@ -706,7 +706,7 @@ cstring_array *near_dupe_hashes_languages(size_t num_components, char **labels, 
         remove_spaces = true;
         log_debug("Doing street expansions for %s\n", place->street);
         normalize_options.address_components = LIBPOSTAL_ADDRESS_STREET | LIBPOSTAL_ADDRESS_ANY;
-        normalize_options.root = options.root;
+        normalize_options.root = options.street_root;
         street_expansions = expanded_component_combined(place->street, normalize_options, remove_spaces, &num_street_expansions);
         log_debug("Got %zu street expansions\n", num_street_expansions);
     }


### PR DESCRIPTION
We found that for near dupes the street name root expansion generated a lot of extra hashes but didn't give us a lot of benefits in terms of blocking, so we ended up disabling it.