### PR TITLE
Makefile is not available until after configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Then to install the C library:
 ```
 git clone https://github.com/openvenues/libpostal
 cd libpostal
-make distclean
 ./bootstrap.sh
 ./configure --datadir=[...some dir with a few GB of space...]
+make distclean
 make -j4
 sudo make install
 


### PR DESCRIPTION
The `make` command fails when run *before* `configure`, this is confusing users which are not familiar with `automake`.

```bash
make distclean
make: *** No rule to make target `distclean'.  Stop.

make
make: *** No targets specified and no makefile found.  Stop.
```

resolves https://github.com/openvenues/libpostal/issues/595