### PR TITLE
docs: remove make distclean

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ git clone https://github.com/openvenues/libpostal
 cd libpostal
 ./bootstrap.sh
 ./configure --datadir=[...some dir with a few GB of space...]
-make distclean
 make -j4
 sudo make install
 


### PR DESCRIPTION
The `make distclean` command is not required in this example, which is a fresh clone

related: https://github.com/openvenues/libpostal/pull/605#issuecomment-1295954750