### PR TITLE
Add support for OpenBLAS

### DIFF
--- a/m4/ax_cblas.m4
+++ b/m4/ax_cblas.m4
@@ -152,12 +152,17 @@ if test $ax_cblas_ok = no; then
             [], [-lblas])])
 fi
 
+# BLAS in OpenBLAS library?
+if test $ax_cblas_ok = no; then
+    AC_CHECK_LIB(openblas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lopenblas"])
+fi
+
 # Generic CBLAS library?
 if test $ax_cblas_ok = no; then
     AC_CHECK_LIB(cblas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lcblas"])
 fi
 
-# Generic BLAS library? (for instance OpenBLAS)
+# Generic BLAS library?
 if test $ax_cblas_ok = no; then
     AC_CHECK_LIB(blas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lblas"])
 fi

--- a/m4/ax_cblas.m4
+++ b/m4/ax_cblas.m4
@@ -157,6 +157,11 @@ if test $ax_cblas_ok = no; then
     AC_CHECK_LIB(cblas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lcblas"])
 fi
 
+# Generic BLAS library? (for instance OpenBLAS)
+if test $ax_cblas_ok = no; then
+    AC_CHECK_LIB(cblas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lblas"])
+fi
+
 AC_SUBST(CBLAS_LIBS)
 
 LIBS="$ax_cblas_save_LIBS"

--- a/m4/ax_cblas.m4
+++ b/m4/ax_cblas.m4
@@ -159,7 +159,7 @@ fi
 
 # Generic BLAS library? (for instance OpenBLAS)
 if test $ax_cblas_ok = no; then
-    AC_CHECK_LIB(cblas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lblas"])
+    AC_CHECK_LIB(blas, cblas_dgemm, [ax_cblas_ok=yes; CBLAS_LIBS="-lblas"])
 fi
 
 AC_SUBST(CBLAS_LIBS)


### PR DESCRIPTION
Hi 👋 

I'd like to compile using [`libopenblas-openmp-dev`](https://packages.debian.org/search?searchon=names&keywords=libopenblas-openmp-dev). OpenBLAS is still [actively](https://www.openblas.net/Changelog.txt) maintained and has optional OpenMP support. In [comparison](https://wiki.debian.org/DebianScience/LinearAlgebraLibraries), the latest ATLAS release is from 2016.

Currently, `cblas_dgemm` will be [recognized](https://github.com/ddelange/libpostal-fastapi/actions/runs/4730353072/jobs/8393956993#step:7:897) but [not used](https://github.com/ddelange/libpostal-fastapi/actions/runs/4730353072/jobs/8393956993#step:7:1116).

This PR [fixes](https://github.com/ddelange/libpostal-fastapi/actions/runs/4730639843/jobs/8395560580#step:7:1026) that.