### PR TITLE
Consider expanding "g-ral" to "general" in Romanian street names

### DIFF
--- a/resources/dictionaries/ro/personal_titles.txt
+++ b/resources/dictionaries/ro/personal_titles.txt
@@ -4,7 +4,7 @@ colonel|col
 comandor
 contra amiral
 doctor|dr
-general|gen
+general|gen|g-ral
 major|maj
 locotenent
 locotenent colonel


### PR DESCRIPTION
I noticed `expand_address` does not expand "g-ral" to "general".

Although I couldn't find an official source for this, a lot of street name signs in Romania abbreviate "General" as "G-ral". People also often abbreviate it like this in all kinds of writing.

* [Strada General Constantin Budișteanu, Bucharest](https://goo.gl/maps/HqGKGfn15JXYG3PbA)
* [Strada General Gheorghe Manu, Bucharest](https://goo.gl/maps/FgdvY33fSXfZpa7S8)
* [Strada General Christian Tell, Bucharest](https://goo.gl/maps/d8rM1tSff5oWqNNEA)
* [Bulevardul General Vasile Milea, Sibiu](https://goo.gl/maps/UcU2eLy11wGmYvEF9)

etc.