### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ brew install curl autoconf automake libtool pkg-config
 
 Then to install the C library:
 
-If you're using an M1 Mac, add `--disable-sse2` to the `./configure` command. This will result in poorer performance but the build will succeed.
+If you're using an M1 Mac or ARM64-based linux distro, add `--disable-sse2` to the `./configure` command. This will result in poorer performance but the build will succeed.
 
 ```
 git clone https://github.com/openvenues/libpostal


### PR DESCRIPTION
# Change Description
Extend the `--disable-sse2` comment to also include ARM64-based linux releases. Without this, the following error occurs:

```
libtool: compile:  gcc -DHAVE_CONFIG_H -I.. -I/usr/local/include -Wall -Wextra -Wno-unused-function -Wformat -Werror=format-security -Winit-self -Wno-sign-compare -DLIBPOSTAL_DATA_DIR=\"/home/ec2-user/libpostal-training/libpostal\" -g -mfpmath=sse -msse2 -DUSE_SSE -g -O2 -O2 -D LIBPOSTAL_EXPORTS -MT libpostal_la-address_dictionary.lo -MD -MP -MF .deps/libpostal_la-address_dictionary.Tpo -c address_dictionary.c  -fPIC -DPIC -o .libs/libpostal_la-address_dictionary.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I.. -I/usr/local/include -Wall -Wextra -Wno-unused-function -Wformat -Werror=format-security -Winit-self -Wno-sign-compare -DLIBPOSTAL_DATA_DIR=\"/home/ec2-user/libpostal-training/libpostal\" -g -mfpmath=sse -msse2 -DUSE_SSE -g -O2 -O2 -D LIBPOSTAL_EXPORTS -MT libpostal_la-expand.lo -MD -MP -MF .deps/libpostal_la-expand.Tpo -c expand.c  -fPIC -DPIC -o .libs/libpostal_la-expand.o
make[2]: *** [libpostal_la-strndup.lo] Error 1
gcc: error: unrecognized command line option '-mfpmath=sse'
gcc: error: unrecognized command line option '-msse2'
gcc: error: unrecognized command line option '-mfpmath=sse'
gcc: error: unrecognized command line option '-msse2'
make[2]: *** [libpostal_la-expand.lo] Error 1
make[2]: *** [libpostal_la-address_dictionary.lo] Error 1
make[2]: Leaving directory `/home/ec2-user/libpostal/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/ec2-user/libpostal'
make: *** [all] Error 2
```

# Pull request questions

## Which issue does this address

N/A; Documentation update

## Why was change needed

To clarify when to use the `--disable-sse2` flag during compilation

## What does change improve

Documentation for installation
