### PR TITLE
Update README.md to include 'build-essential' package in apt list and 3 common configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd libpostal
 ./configure --datadir=[...some dir with a few GB of space...]
 
 # For Apple / ARM cpus and the default model
-./configure --datadir=/tmp --disable-sse2
+./configure --datadir=[...some dir with a few GB of space...] --disable-sse2
 
 # For the improved Senzing model:
 ./configure --datadir=[...some dir with a few GB of space...] MODEL=senzing

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Before you install, make sure you have the following prerequisites:
 
 **On Ubuntu/Debian**
 ```
-sudo apt-get install curl autoconf automake libtool pkg-config
+sudo apt-get install -y curl build-essential autoconf automake libtool pkg-config
 ```
 
 **On CentOS/RHEL**
@@ -118,9 +118,19 @@ If you're using an M1 Mac, add `--disable-sse2` to the `./configure` command. Th
 ```
 git clone https://github.com/openvenues/libpostal
 cd libpostal
+
 ./bootstrap.sh
+
+# For Intel/AMD processors and the default model
 ./configure --datadir=[...some dir with a few GB of space...]
-make -j4
+
+# For Apple / ARM cpus and the default model
+./configure --datadir=/tmp --disable-sse2
+
+# For the improved Senzing model:
+./configure --datadir=[...some dir with a few GB of space...] MODEL=senzing
+
+make -j8
 sudo make install
 
 # On Linux it's probably a good idea to run


### PR DESCRIPTION
@albarrentine can this get some love?

1) There was a package missing from the Ubuntu requirements: `build-essential`. I added it.
2) I show 3 common configuration options: x86, Macs and the Senzing data model