### PR TITLE
Remove unused regex that can cause exponential backtracking when used

### DIFF
--- a/scripts/geodata/i18n/transliteration_rules.py
+++ b/scripts/geodata/i18n/transliteration_rules.py
@@ -183,10 +183,6 @@ def replace_literal_space(m):
 regex_char_set_greedy = re.compile(r'\[(.*)\]', re.UNICODE)
 regex_char_set = re.compile(r'\[(.*?)(?<!\\)\]', re.UNICODE)
 
-char_class_regex_str = '\[(?:[^\[\]]*\[[^\[\]]*\][^\[\]]*)*[^\[\]]*\]'
-
-nested_char_class_regex = re.compile('\[(?:[^\[\]]*\[[^\[\]]*\][^\[\]]*)+[^\[\]]*\]', re.UNICODE)
-
 range_regex = re.compile(r'[\\]?([^\\])\-[\\]?([^\\])', re.UNICODE)
 var_regex = re.compile('[\s]*\$([A-Za-z_\-]+[A-Za-z_0-9\-]*)[\s]*')
 


### PR DESCRIPTION
These regex may cause exponential backtracking on strings starting with '\[\[\]' and containing many repetitions of 'Z\[\]'. 
There is no active usage of these regex in the code, removing it as a precaution to avoid any future uses.

From copilot for more context, such regular expressions can negatively affect performance, or even allow a malicious user to perform a Denial of Service  attack by crafting an expensive input string for the regular expression to match. The regular expression engine provided by Python uses a backtracking non-deterministic finite automata to implement regular expression matching. While this approach is space-efficient and allows supporting advanced features like capture groups, it is not time-efficient in general . 