### PR TITLE
Support more arm processors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ AC_ARG_ENABLE([sse2],
         )
     )
 
-AS_IF([test "x$enable_sse2" != "xno" && test "x$(uname -m)" != "xarm64"], [
+AS_IF([test "x$enable_sse2" != "xno" && test "x$(uname -m)" != "xarm64" && test "x$(uname -m)" != "xaarch64"], [
     CFLAGS="-mfpmath=sse -msse2 -DUSE_SSE ${CFLAGS}"
 ])
 


### PR DESCRIPTION
In some cases `uname -m` returns `aarch64` rather than `arm64` for arm CPUs.

This PR should let libpostal build correctly in those cases. 

PR is based on this one for apple silicon support: https://github.com/openvenues/libpostal/pull/679