### PR TITLE
Fix error in function calling.

### DIFF
--- a/src/libpostal.c
+++ b/src/libpostal.c
@@ -214,7 +214,7 @@ libpostal_fuzzy_duplicate_status_t libpostal_is_street_duplicate_fuzzy(size_t nu
 }
 
 libpostal_language_classifier_response_t *libpostal_classify_language(char *address) {
-    libpostal_language_classifier_response_t *response = classify_languages(address);
+    libpostal_language_classifier_response_t *response = libpostal_classify_languages(address);
 
     if (response == NULL) {
         log_error("Language classification returned NULL\n");


### PR DESCRIPTION
When trying to build via AUR, an error is introduced while doing `makepkg -si`. The error was:
```libpostal.c: In function 'libpostal_classify_language':
libpostal.c:206:58: error: initialization of 'libpostal_language_classifier_response_t *' {aka 'struct libpostal_language_classifier_response *'} from incompatible pointer type 'language_classifier_response_t *' {aka 'struct language_classifier_response *'} [-Wincompatible-pointer-types]
  206 |     libpostal_language_classifier_response_t *response = classify_languages(address);
```
Upon going through the code, I figured the problem was in this function:
```c
libpostal_language_classifier_response_t *libpostal_classify_language(char *address) {
    libpostal_language_classifier_response_t *response = classify_languages(address);
    if (response == NULL) {
        log_error("Language classification returned NULL\n");
        return NULL;
    }

    return response;
}
```
Replacing `libpostal_language_classifier_response_t *response = classify_languages(address);` 
with 
`libpostal_language_classifier_response_t *response =
    (libpostal_language_classifier_response_t *) classify_languages(address);` 
seems to have fixed the issue for me.
I'm currently running arch linux with kde plasma if that's required to know.